### PR TITLE
Re-add `rel` feature missing due to merge conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # oEmbed Changelog
 
+## 1.2.1 - 2020-01-19
+
+### Updated
+- Re-add `rel` feature missing due to merge conflict. ([#24](https://github.com/wrav/oembed/issues/24))
+
 ## 1.2.0 - 2020-01-19
 
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -87,6 +87,11 @@ class OembedService extends Component
                     $src = preg_replace('/\?(.*)$/i', '?autopause='. (!!$options['autopause'] ? '1' : '0') .'&${1}', $src);
                 }
 
+                // Rel
+                if (!empty($options['rel']) && strpos($html, 'rel=') === false && $src) {
+                    $src = preg_replace('/\?(.*)$/i', '?rel='. (!!$options['rel'] ? '1' : '0') .'&${1}', $src);
+                }
+
                 $iframe->setAttribute('src', $src);
                 $media->code = $dom->saveXML($iframe);
             } catch (\Exception $exception) {


### PR DESCRIPTION
### Updated
- Re-add `rel` feature missing due to merge conflict. ([#24](https://github.com/wrav/oembed/issues/24))
