### PR TITLE
Add new option to allow setting of iframe URL query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # oEmbed Changelog
 
+## 1.2.2 - 2020-01-30
+
+### Updated
+- Updated README with usage of new feature.
+
+### Added
+- *(NEW FEATURE)* Add new `params` option to allow you to set missing URL query params that are supported by the providers oembed protocol. ([#24](https://github.com/wrav/oembed/issues/24) & [#30](https://github.com/wrav/oembed/issues/30))
+
 ## 1.2.1 - 2020-01-19
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ We also provide option to use as a Twig variable
     {% set embed = craft.oembed.embed(url, options) %}
     {% set media = craft.oembed.media(url, options) %}
     
+Updating the embed URL , such as autoplay, rel, mute paramaters. This allows for you to support features the provider might not yet support
+
+    {{ 
+        entry.oembed_field.render({
+            params: {
+                autoplay: 1,
+                rel: 0,
+                mute: 0,
+                loop: 1,
+                autopause: 1,
+            }
+        }) 
+    }}
+    
 You can access additional media details using the examples below.
 
     entry.field.media.title

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -63,6 +63,7 @@ class OembedService extends Component
                 };
             }
 
+
             // Wrapping to be safe :)
             try {
                 $html = $media->code;
@@ -71,6 +72,12 @@ class OembedService extends Component
 
                 $iframe = $dom->getElementsByTagName('iframe')->item(0);
                 $src = $iframe->getAttribute('src');
+
+                if(!empty($options['params'])) {
+                    foreach((array)$options['params'] as $key => $value) {
+                        $src = preg_replace('/\?(.*)$/i', '?'.$key.'='. $value .'&${1}', $src);
+                    }
+                }
 
                 // Autoplay
                 if (!empty($options['autoplay']) && strpos($html, 'autoplay=') === false && $src) {


### PR DESCRIPTION
Add new option to allow you to set missing URL query params that are…supported by the providers oembed protocol. ([#29](https://github.com/wrav/oembed/issues/29) & [#30](https://github.com/wrav/oembed/issues/30))