### PR TITLE
PHP 7.0-compatible changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # oEmbed Changelog
 
+## 1.2.4 - 2020-02-05
+
+### Updated
+- Removed package dependacy to get PHP 7.0-compatible ([#33](https://github.com/wrav/oembed/issues/33))
+
 ## 1.2.3 - 2020-02-05
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "keywords": [
         "craft",
         "cms",

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
     ],
     "require": {
         "craftcms/cms": "^3.0.0-beta.23",
-        "embed/embed": "^3.3",
-        "laravel/helpers": "^1.1"
+        "embed/embed": "^3.3"
     },
     "repositories": [
         {


### PR DESCRIPTION
### Updated
- Removed package dependacy to get PHP 7.0-compatible ([#33](https://github.com/wrav/oembed/issues/33))
