### PR TITLE
Collapse preview by default

### DIFF
--- a/src/assetbundles/oembed/dist/css/oembed.css
+++ b/src/assetbundles/oembed/dist/css/oembed.css
@@ -1,13 +1,40 @@
 .oembed-header {
   margin: 0.5rem 0;
   background: #f3f7fc;
-  padding: 10px 15px;
-  cursor: pointer
+  padding: 10px 0;
+  cursor: pointer;
 }
 
 .oembed-preview {
   width: 100%;
+  position: relative;
+}
+
+.oembed-preview.has-embed {
+  height: 120px;
   overflow: hidden;
+  pointer-events: none;
+}
+
+.oembed-preview.has-embed:after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0), #f3f7fc);
+  width: 100%;
+  height: 100px;
+}
+
+.oembed-preview.has-embed.expanded {
+  height: auto;
+  pointer-events: auto;
+}
+
+.oembed-preview.has-embed.expanded:after {
+  content: none;
 }
 
 .oembed-preview iframe {

--- a/src/assetbundles/oembed/dist/css/oembed.css
+++ b/src/assetbundles/oembed/dist/css/oembed.css
@@ -15,6 +15,9 @@
   overflow: hidden;
   pointer-events: none;
 }
+.oembed-preview.default-hidden.has-embed {
+  height: 0;
+}
 
 .oembed-preview.has-embed:after {
   content: "";

--- a/src/assetbundles/oembed/dist/js/oembed.js
+++ b/src/assetbundles/oembed/dist/js/oembed.js
@@ -16,12 +16,12 @@ $('body').on('click', '.oembed-header', function () {
     var oembedPreview = $(this).parent().find('.oembed-preview');
     var icon = $(this).parent().find('.oembed-header *[data-icon-after]');
 
-    oembedPreview.toggleClass('hidden');
+    oembedPreview.toggleClass('expanded');
 
-    if(oembedPreview.hasClass('hidden')) {
-        icon.attr('data-icon-after', 'expand')
-    } else {
+    if(oembedPreview.hasClass('expanded')) {
         icon.attr('data-icon-after', 'collapse')
+    } else {
+        icon.attr('data-icon-after', 'expand')
     }
 });
 
@@ -45,12 +45,12 @@ $('body').on('keyup blur change', 'input.oembed-field', function () {
                 async: true
             }).done(function (res) {
                 var preview = that.parent().find('.oembed-preview');
-                preview.html('');
+                preview.html('').removeClass('hidden');
 
                 if (res) {
-                    preview.html(res);
+                    preview.addClass('has-embed').html(res);
                 } else {
-                    preview.html(
+                    preview.removeClass('has-embed').html(
                         '<p class="error">Please check your URL.</p>'
                     );
                 }

--- a/src/assetbundles/oembed/dist/js/oembed.js
+++ b/src/assetbundles/oembed/dist/js/oembed.js
@@ -39,16 +39,18 @@ $('body').on('keyup blur change', 'input.oembed-field', function () {
         var cpTrigger = Craft && Craft.cpTrigger ? Craft.cpTrigger : 'admin';
 
         if(val) {
+            var preview = that.parent().find('.oembed-preview');
+            preview.removeClass('has-embed').html(
+                '<p>Loading...</p>'
+            );
+
             $.ajax({
                 type: "GET",
                 url: "/"+cpTrigger.toString()+"/oembed/preview?url=" + val + "&options[]=",
                 async: true
             }).done(function (res) {
-                var preview = that.parent().find('.oembed-preview');
-                preview.html('').removeClass('hidden');
-
                 if (res) {
-                    preview.addClass('has-embed').html(res);
+                    preview.addClass('has-embed expanded').html(res);
                 } else {
                     preview.removeClass('has-embed').html(
                         '<p class="error">Please check your URL.</p>'

--- a/src/fields/OembedField.php
+++ b/src/fields/OembedField.php
@@ -148,6 +148,7 @@ class OembedField extends Field
     public function getInputHtml($value, ElementInterface $element = null): string
     {
         $settings = Oembed::getInstance()->getSettings();
+        $hidden = $settings['previewHidden'];
 
         $input = '<input name="'.$this->handle.'" class="text nicetext fullwidth oembed-field" value="'.$value.'" />';
         $preview = '<div class="oembed-header">
@@ -158,9 +159,10 @@ class OembedField extends Field
             try {
                 if ($embed = new OembedModel($value)) {
                     $embed = $embed->embed();
+                    $hiddenClass = $hidden ? 'default-hidden' : '';
 
                     if (!empty($embed)) {
-                        $preview .= '<div class="oembed-preview has-embed">'.$embed->code.'</div>';
+                        $preview .= '<div class="oembed-preview has-embed ' . $hiddenClass . ' / ">'.$embed->code.'</div>';
                     } else {
                         $preview .= '<div class="oembed-preview"><p class="error">Please check your URL.</p></div>';
                     }

--- a/src/fields/OembedField.php
+++ b/src/fields/OembedField.php
@@ -148,7 +148,7 @@ class OembedField extends Field
     public function getInputHtml($value, ElementInterface $element = null): string
     {
         $settings = Oembed::getInstance()->getSettings();
-        $hidden = $settings['previewHidden'];
+        $hiddenClass = $settings['previewHidden'] ? 'default-hidden' : '';
 
         $input = '<input name="'.$this->handle.'" class="text nicetext fullwidth oembed-field" value="'.$value.'" />';
         $preview = '<div class="oembed-header">
@@ -159,19 +159,18 @@ class OembedField extends Field
             try {
                 if ($embed = new OembedModel($value)) {
                     $embed = $embed->embed();
-                    $hiddenClass = $hidden ? 'default-hidden' : '';
 
                     if (!empty($embed)) {
                         $preview .= '<div class="oembed-preview has-embed ' . $hiddenClass . ' / ">'.$embed->code.'</div>';
                     } else {
-                        $preview .= '<div class="oembed-preview"><p class="error">Please check your URL.</p></div>';
+                        $preview .= '<div class="oembed-preview ' . $hiddenClass . '"><p class="error">Please check your URL.</p></div>';
                     }
                 }
             } catch (\Exception $exception) {
-                $preview .= '<div class="oembed-preview"><p class="error">Please check your URL.</p></div>';
+                $preview .= '<div class="oembed-preview ' . $hiddenClass . '"><p class="error">Please check your URL.</p></div>';
             }
         } else {
-            $preview .= '<div class="oembed-preview"></div>';
+            $preview .= '<div class="oembed-preview ' . $hiddenClass . '"></div>';
         }
         return $input.$preview;
     }

--- a/src/fields/OembedField.php
+++ b/src/fields/OembedField.php
@@ -148,13 +148,10 @@ class OembedField extends Field
     public function getInputHtml($value, ElementInterface $element = null): string
     {
         $settings = Oembed::getInstance()->getSettings();
-        $hidden = $settings['previewHidden'];
-        $previewIcon = $hidden ? 'expand' : 'collapse';
-
 
         $input = '<input name="'.$this->handle.'" class="text nicetext fullwidth oembed-field" value="'.$value.'" />';
         $preview = '<div class="oembed-header">
-                      <p class="fullwidth"><strong>Preview</strong> <span class="right" data-icon-after="'.$previewIcon.'"></span></p>
+                      <p class="fullwidth"><strong>Preview</strong> <span class="right" data-icon-after="expand"></span></p>
                     </div>';
 
         if ($value) {
@@ -162,12 +159,10 @@ class OembedField extends Field
                 if ($embed = new OembedModel($value)) {
                     $embed = $embed->embed();
 
-                    $hiddenClass = $hidden ? 'hidden' : '';
-
                     if (!empty($embed)) {
-                        $preview .= '<div class="oembed-preview '.$hiddenClass.'">'.$embed->code.'</div>';
+                        $preview .= '<div class="oembed-preview has-embed">'.$embed->code.'</div>';
                     } else {
-                        $preview .= '<div class="oembed-preview '.$hiddenClass.'"><p class="error">Please check your URL.</p></div>';
+                        $preview .= '<div class="oembed-preview"><p class="error">Please check your URL.</p></div>';
                     }
                 }
             } catch (\Exception $exception) {

--- a/src/templates/preview.twig
+++ b/src/templates/preview.twig
@@ -1,5 +1,4 @@
 {% set media = craft.oembed.embed(url) %}
-
 {% if media and media.code|default(false) %}
     {{ media.code|default('')|raw }}
 {% else %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -20,7 +20,7 @@
 
 {{ forms.lightswitchField({
     label: "Previews hidden by default"|t,
-    instructions: "This will hide preview in collapsable component"|t,
+    instructions: "This will hide previews in a collapsable component."|t,
     id: 'previewHidden',
     name: 'previewHidden',
     on: settings.previewHidden,


### PR DESCRIPTION
@reganlawton This is what I was thinking. Basically, you'd semi-collapse previews by default. This keeps the CP condensed but still gives the author a sense that the embed worked.

This would remove the need for the "Previews hidden by default" setting, I think, but I didn't want to strip all of that out just yet.

No worries if you prefer your solution better, just thought I'd give this one a try.

Here is a screenshot of the default state looks like:
<img width="775" alt="Screen Shot 2020-03-20 at 4 44 10 PM" src="https://user-images.githubusercontent.com/378665/77214135-d9e7b300-6aca-11ea-8410-0ff67a180c8a.png">