### PR TITLE
Fixing serialization of 'class@anonymous'

### DIFF
--- a/src/adapters/FallbackAdapter.php
+++ b/src/adapters/FallbackAdapter.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * oEmbed plugin for Craft CMS 3.x
+ *
+ * A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.
+ *
+ * @link      https://github.com/wrav
+ * @copyright Copyright (c) 2017 reganlawton
+ */
+
+namespace wrav\oembed\adapters;
+
+use Embed\Adapters\Adapter;
+use Embed\Utils;
+
+class FallbackAdapter extends Adapter
+{
+    protected function init()
+    {
+        $this->providers = [];
+    }
+
+    public function getCode()
+    {
+        return Utils::iframe($this->url);
+    }
+}


### PR DESCRIPTION
Instead of creating an anonymous class if requests have failed, this change now uses a fallback adapter, which always returns an iFrame code. Anonymous classes can not be cached.

This change also reduces the caching duration for failed requests to 15 minutes.

Fixes #81, #76