### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Updating the embed URL, such as autoplay, rel, mute paramaters. This allows for 
             params: {
                 autoplay: 1,
                 rel: 0,
-                mute: 0,
+                muted: 0,
                 loop: 1,
                 autopause: 1,
             },


### PR DESCRIPTION
Vimeo parameters need `muted=1` to mute the video, which then allows the video to auto-play as per Chrome's policy (https://developers.google.com/web/updates/2017/09/autoplay-policy-changes)
Not sure if this breaks for other providers