### PR TITLE
Fix missing Embed\Utils import in OembedService.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "1.3.14",
+    "version": "1.3.15",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -19,6 +19,7 @@ use Embed\Adapters\Adapter;
 use Embed\Embed;
 use Embed\Exceptions\InvalidUrlException;
 use Embed\Http\CurlDispatcher;
+use Embed\Utils;
 use wrav\oembed\adapters\FallbackAdapter;
 use wrav\oembed\events\BrokenUrlEvent;
 use wrav\oembed\Oembed;


### PR DESCRIPTION
Sorry for this, but there was a missing import in my previous pull request preventing the fix from working.