### PR TITLE
Fix missing Embed\Utils import in OembedService.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     ],
     "require": {
         "craftcms/cms": "^4.0",
-        "embed/embed": "^3.3"
+        "embed/embed": "^3.3",
+        "ext-dom": "*"
     },
     "repositories": [
         {
@@ -55,5 +56,11 @@
             "oembedService": "wrav\\oembed\\services\\OembedService"
         },
         "class": "wrav\\oembed\\Oembed"
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
     }
 }

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -19,6 +19,7 @@ use Embed\Adapters\Adapter;
 use Embed\Embed;
 use Embed\Exceptions\InvalidUrlException;
 use Embed\Http\CurlDispatcher;
+use Embed\Utils;
 use wrav\oembed\adapters\FallbackAdapter;
 use wrav\oembed\events\BrokenUrlEvent;
 use wrav\oembed\Oembed;


### PR DESCRIPTION
@reganlawton 
Hi, here is the PR related to the previous one for Craft 3.
In fact, OembedService.php hasn't changed so much between v1 and v2 version and I could confirm that the v2 version is also affected by the issue.
Please note that **I did not** update the composer.json version number (still referenced as `2.0.0`). Also, I've added "ext-dom" as a needed dependency (because of the use of `DOMDocument`). Feel free to adjust that in any way.