### PR TITLE
fix: add missing height property

### DIFF
--- a/src/adapters/FallbackAdapter.php
+++ b/src/adapters/FallbackAdapter.php
@@ -15,6 +15,8 @@ use Embed\Utils;
 
 class FallbackAdapter extends Adapter
 {
+    public $height;
+
     protected function init()
     {
         $this->providers = [];


### PR DESCRIPTION
Hi

Thanks a lot for your ongoing work on the plugin!

On an installation running oembed 1.3.17, PHP 8.0.20 and Craft CMS 3.7.46, I repeatedly ran into the following error:
`Undefined property: wravloembed\adapters\FallbackAdapter::$height`.

I'm not sure whether it could've been caused by the PHP version or a plugin update. Without looking into it too much I tried to simply add the property to the class, which resolves the error for me.

It could, however, be the case that this has some side effects I'm not aware of. As the maintainer, you probably know best how to test the code and if this commit is helpful/harmless or has unintentional consequences. 

Thanks a lot!
 
<img width="911" alt="Screenshot 2022-06-29 at 09 43 13" src="https://user-images.githubusercontent.com/5810772/176466082-1bf38676-dc2e-42eb-93cc-0abdca3adbc2.png">
