### PR TITLE
fix: Fix for FallbackAdapter not being handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # oEmbed Changelog
 
+## 2.2.1 - 2022-06-30
+
+### Update
+- Fix a side effect of #101 fix where the preview and embed will fallback to the default Craft site if no or invalid URL is provided (@juban)
+
 ## 2.2.0 - 2022-06-30
 
 ### Update

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -101,8 +101,8 @@ class OembedService extends Component
             try {
                 $dom = new DOMDocument;
                 $code = $media->getCode();
-                if (empty($code)) {
-                    $code = Utils::iframe($media->url);
+                if (empty($code) && !($media instanceof FallbackAdapter)) {
+                    $code = empty((string)$url) ? '' : Utils::iframe($media->url);
                 }
                 $dom->loadHTML($code);
 


### PR DESCRIPTION
Fix the side effect of #101 fix where the preview and embed will fallback to the default Craft site if no or invalid URL is provided.