### PR TITLE
Fix Craft 4 type compatibility

### DIFF
--- a/src/gql/OembedFieldResolver.php
+++ b/src/gql/OembedFieldResolver.php
@@ -18,7 +18,7 @@ class OembedFieldResolver extends ObjectType
     /**
      * @inheritdoc
      */
-    protected function resolve($source, $arguments, $context, ResolveInfo $resolveInfo)
+    protected function resolve($source, $arguments, $context, ResolveInfo $resolveInfo): mixed
     {
         $fieldName = $resolveInfo->fieldName;
 


### PR DESCRIPTION
This plugin is currently incompatible with Craft 4 GraphQL because of type declarations. This change is required to make the plugin compatible.

> Declaration of wrav\\oembed\\gql\\OembedFieldResolver::resolve($source, $arguments, $context, GraphQL\\Type\\Definition\\ResolveInfo $resolveInfo) must be compatible with craft\\gql\\base\\ObjectType::resolve(mixed $source, array $arguments, mixed $context, GraphQL\\Type\\Definition\\ResolveInfo $resolveInfo): mixed