### PR TITLE
provide default values for width and height to avoid graphql bug

### DIFF
--- a/src/adapters/FallbackAdapter.php
+++ b/src/adapters/FallbackAdapter.php
@@ -18,6 +18,8 @@ class FallbackAdapter extends Adapter
     protected function init()
     {
         $this->providers = [];
+        $this->height = null;
+        $this->width = null;
     }
 
     public function getCode()


### PR DESCRIPTION
adds null to width and height.  This avoids a fatal error that occurs when querying the field using graphql and the field is empty.