### PR TITLE
Early compatibility with Craft 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "roave/security-advisories": "dev-latest"
     },
     "require": {
-        "craftcms/cms": "^4.0",
+        "craftcms/cms": "^4.0 | ^5.0",
         "embed/embed": "^v4.4",
         "ext-dom": "*"
     },


### PR DESCRIPTION
Hi! 

Since I'm working on a project that will release after Craft 5, we already bit the bullet and currently work on the alpha actively. I wanted to install your plugin to test its compatibility and everything works fine as far as I'm concerned, only by changing the version number in the composer.json file. Granted this pull request might be early, but this would just allow the install on v5 for those who want to try and start reporting bugs early. 

Have a nice day! 🤘