### PR TITLE
Fix for: GrapQL - Error when querying an entry with a empty oEmbed URL

### DIFF
--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -86,7 +86,7 @@ class OembedService extends Component
 
             $embed = new Embed();
             $infos = $embed
-                ->get($url)
+                ->get($url ?: "")
             ;
             $infos->setSettings($options);
             $data = $infos->getOEmbed()->all();


### PR DESCRIPTION
Small fix for: #156 