### PR TITLE
Don't register assets on control panel requests

### DIFF
--- a/src/Oembed.php
+++ b/src/Oembed.php
@@ -119,7 +119,7 @@ class Oembed extends Plugin
         );
 
         // Register Assets
-        if (!Craft::$app->getRequest()->getIsSiteRequest()) {
+        if (!Craft::$app->getRequest()->getIsSiteRequest() && !Craft::$app->getRequest()->getIsConsoleRequest()) {
             Craft::$app->getView()->registerAssetBundle(OembedAsset::class);
         }
 


### PR DESCRIPTION
Assets are now loaded with console requests, which breaks the Craft CLI. This check prevents the asset bundle from being registered on a console request.

Relates to #158 