### PR TITLE
Add functionality to parse CKEditor's oembed tags

### DIFF
--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -55,6 +55,25 @@ class OembedService extends Component
     }
 
     /**
+     * @param string $input 
+     * @param array $options
+     * @return string 
+     */
+    public function parseTags(string $input, array $options = [], array $cacheProps = [])
+    {
+        if (empty($input)) {
+            return '';
+        }
+        
+        $output = preg_replace_callback('/\<oembed\s(?:.*?)url="(.*?)"(?:.*?)>(?:.*?)<\/oembed>/i', function($matches) {
+            $url = $matches[1];
+            return $this->render($url, $options, $cacheProps);
+        }, $input);
+
+        return $output;
+    }
+
+    /**
      * @param $url
      * @param array $options
      * @return Media|string

--- a/src/variables/OembedVariable.php
+++ b/src/variables/OembedVariable.php
@@ -75,4 +75,22 @@ class OembedVariable
         $media = $this->embed($url, $options, $cacheProps);
         return (!empty($media) && isset($media->code));
     }
+
+    /**
+     * Call it like this:
+     *
+     *     {{ craft.oembed.parseTags(input, options) }}
+     *
+     * @param $input
+     * @param array $options
+     * @return string
+     */
+    public function parseTags($input, array $options = [], array $cacheProps = [])
+    {
+        if (empty($input)) {
+            return null;
+        }
+
+        return Oembed::getInstance()->oembedService->parseTags($input, $options, $cacheProps);
+    }
 }


### PR DESCRIPTION
I recently needed to output embeds added in CKEditor using it's Media embed feature: https://github.com/craftcms/ckeditor?tab=readme-ov-file#embedding-media

So I created a simple parser that finds every `<oembed url="https://embed.url"></oembed>` tag in a text and runs it's url through the render method.