### PR TITLE
Allow oEmbed html other than iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # oEmbed Changelog
 
+## 3.1.4 - 2025-03-06
+
+### Update
+
+- Allow oEmbed code that includes an iframe to render all of it's HTML instead of just the iframe
+
 ## 3.1.3 - 2024-12-10
 
 ### Update

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wrav/oembed",
     "description": "A simple plugin to extract media information from websites, like youtube videos, twitter statuses or blog articles.",
     "type": "craft-plugin",
-    "version": "3.1.3",
+    "version": "3.1.4",
     "keywords": [
         "craft",
         "cms",

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -268,7 +268,7 @@ class OembedService extends Component
                 }
 
                 // If we were unable to get the main element fall back to the iframe
-                if($mainElement !== null) {
+                if($mainElement === null) {
                     $mainElement = $iframe;
                 }
 

--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -240,8 +240,40 @@ class OembedService extends Component
                 // Set the SRC
                 $iframe->setAttribute('src', $src);
 
+                // Get the main element
+                $mainElement = null;
+                $bodyItem = $dom->getElementsByTagName('body')->item(0);
+                if($bodyItem !== null) {
+                    if ($bodyItem->childNodes->count() === 1) {
+                        // Body only contains 1 child, use that
+                        $mainElement = $bodyItem->childNodes->item(0);
+                    } else {
+                        // Body contains multiple children, wrap in div
+                        $mainElement = $dom->createElement('div');
+
+                        // Collect all body children
+                        $bodyChildren = [];
+                        foreach ($bodyItem->childNodes as $child) {
+                            $bodyChildren[] = $child;
+                        }
+
+                        // Move all body children to the div
+                        foreach ($bodyChildren as $child) {
+                            $mainElement->appendChild($child);
+                        }
+                        
+                        // Add div back to body
+                        $bodyItem->appendChild($mainElement);
+                    }
+                }
+
+                // If we were unable to get the main element fall back to the iframe
+                if($mainElement !== null) {
+                    $mainElement = $iframe;
+                }
+
                 // Set the code
-                $code = $dom->saveXML($iframe, LIBXML_NOEMPTYTAG);
+                $code = $dom->saveXML($mainElement, LIBXML_NOEMPTYTAG);
 
                 // Apply the code to the media object
                 $media->code = $code;


### PR DESCRIPTION
At the moment when parsing the oEmbed HTML, only the iframe is extracted from the returned embed media code.
This works fine in most cases, but it can break embeds that require more then the ifame. For example an embed url like 
https://share.synthesia.io/5a150cb1-0ed9-4f46-bc6f-449f2c3ddb96

The embed code for this site also includes a wrapper div, without this the embed layout breaks and makes the embed input field in the control panel invisible.

To fix this I made the function that manipulates the HTML return the first element if there is only 1 element (which will usually be the iframe) and if there are multiple root elements create a wrapping div to return.