### PR TITLE
fix: escape unencoded ampersands before DOM parsing

### DIFF
--- a/src/services/OembedService.php
+++ b/src/services/OembedService.php
@@ -150,7 +150,10 @@ class OembedService extends Component
                     $html = empty((string)$url) ? '' : '<iframe src="'.$url.'"></iframe>';
                     $dom->loadHTML($html);
                 } else {
-                    $dom->loadHTML($data['html']);
+                    $html = $data['html'];
+                    $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+                    $html = preg_replace('/&(?!#?[a-z0-9]+;)/i', '&amp;', $html);
+                    $dom->loadHTML($html);
                 }
 
                 $iframe = $dom->getElementsByTagName('iframe')->item(0);


### PR DESCRIPTION
Many providers (SoundCloud, TikTok, etc.) return embed HTML with raw “&” inside attribute values.
DOMDocument::loadHTML() treats those as the start of an HTML entity; when no “;” follows it throws the warning

`htmlParseEntityRef: expecting ';' in Entity, line: 1`

This results in oembed falling back to the default embed and no atrributes are added to the iframe if they were provided.

Tested with: https://soundcloud.com/storymuseum/anansi-and-the-collection-of-stories-told-by-amantha-edmead

```
{{ item.soundcloudLink.render({
    attributes: {
        'width': 640,
        'height': 480,
        'allow': 'autoplay'
    }
}) }}
```